### PR TITLE
Add Verbose Option

### DIFF
--- a/src/mw.ts
+++ b/src/mw.ts
@@ -26,7 +26,7 @@ type Options = {
    * By default the middleware prints loaded schemas, and other helpful
    * output. Set this to true to disable.
    */
-  quiet?: boolean
+  quiet?: boolean;
 }
 
 


### PR DESCRIPTION
This allows setting `verbose: false` to disable console logging.

When utilizing a Curveball app during tests (via `app.subRequest`) having all the schema's get printed for each test drowns out the potentially useful output from the tests.

This PR allows optionally disabling that output, which can be used during a test run context.