### PR TITLE
Explose ajv and schemas in Context

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+0.9.0 (2022-06-11)
+------------------
+
+* The plugin now creates a `.schemas` and `.ajv` properties on `Context`,
+  to make it easy to access the ajv instance from other contexts.
+
+
 0.8.4 (2022-03-14)
 -----------------
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "ajv-formats": "^2.1.0"
       },
       "devDependencies": {
+        "@curveball/bodyparser": "^0.4.14",
         "@curveball/core": "^0.17",
         "@types/chai": "^4.2.15",
         "@types/mocha": "^9.0.0",
@@ -456,6 +457,15 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@curveball/bodyparser": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@curveball/bodyparser/-/bodyparser-0.4.14.tgz",
+      "integrity": "sha512-KVEO75zIRzIS0qgaHwRJajspZgxEDkZiEDs9wKPFSxcsguj1BM+VTFUPzQoNQnx6S4+pBlOkkEIl/aC9hPo0kg==",
+      "dev": true,
+      "peerDependencies": {
+        "@curveball/core": ">=0.16.2 <1"
       }
     },
     "node_modules/@curveball/controller": {
@@ -4380,6 +4390,13 @@
       "requires": {
         "@cspotcode/source-map-consumer": "0.8.0"
       }
+    },
+    "@curveball/bodyparser": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@curveball/bodyparser/-/bodyparser-0.4.14.tgz",
+      "integrity": "sha512-KVEO75zIRzIS0qgaHwRJajspZgxEDkZiEDs9wKPFSxcsguj1BM+VTFUPzQoNQnx6S4+pBlOkkEIl/aC9hPo0kg==",
+      "dev": true,
+      "requires": {}
     },
     "@curveball/controller": {
       "version": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "homepage": "https://github.com/curveball/validator#readme",
   "devDependencies": {
+    "@curveball/bodyparser": "^0.4.14",
     "@curveball/core": "^0.17",
     "@types/chai": "^4.2.15",
     "@types/mocha": "^9.0.0",

--- a/src/declarations.ts
+++ b/src/declarations.ts
@@ -1,9 +1,32 @@
 import '@curveball/core';
+import Ajv from 'ajv';
+import { SchemaInfo } from './types';
 
 declare module '@curveball/core' {
 
   interface Request {
+
+    /**
+     * Validate the request body against a JSON schema.
+     */
     validate: <T>(schemaId: string) => asserts this is Request<T>;
+
+  }
+
+  interface Context {
+
+    /**
+     * List of JSON schemas
+     */
+    schemas: SchemaInfo[];
+
+    /**
+     * AJV instance.
+     *
+     * This has all the loaded schemas precompiled.
+     */
+    ajv: Ajv;
+
   }
 
 }

--- a/src/mw.ts
+++ b/src/mw.ts
@@ -50,6 +50,9 @@ export default function(options: string|Options): Middleware {
 
   return async (ctx, next) => {
 
+    ctx.ajv = ajv;
+    ctx.schemas = schemas;
+
     ctx.request.validate = (schemaId: string) => {
       const result = ajv.validate(schemaId, ctx.request.body);
       if (result) {
@@ -80,7 +83,7 @@ export default function(options: string|Options): Middleware {
 
     await next();
 
-    if (!trueOptions.noLink && ctx.path === '/') {
+    if (!trueOptions.noLink && ctx.path === '/' && ctx.response.links !== undefined) {
       // If we're on the home document, add a link to the
       // schema collection.
       ctx.response.links.add({

--- a/test/schemas/article.json
+++ b/test/schemas/article.json
@@ -1,0 +1,5 @@
+{
+  "$id": "http://example/schema/article.json",
+  "type": "object",
+  "required": ["title"]
+}

--- a/test/test.ts
+++ b/test/test.ts
@@ -1,5 +1,62 @@
-describe('this package', () => {
-  it('should have tests', () => {
-    // Write your test here
+import { Application, Context } from '@curveball/core';
+import validator from '../src';
+import { expect } from 'chai';
+import bodyParser from '@curveball/bodyparser';
+
+describe('Validator middleware', () => {
+
+  it('should create properties on Context', async () => {
+
+    const app = getApp();
+
+    let result = false;
+
+    app.use( ctx => {
+
+      ctx.response.body = 'ok';
+      expect(ctx.schemas).to.be.an('Array');
+      expect(ctx.ajv).to.be.an('Object');
+      expect(ctx.request.validate).to.be.a('Function');
+      result = true;
+
+    });
+
+    await app.subRequest(
+      'GET',
+      '/',
+    );
+
+    expect(result).to.equal(true);
+
   });
+
+  it('should emit a 422 if validation failed', async () => {
+
+    const app = getApp();
+    app.use( (ctx: Context) => {
+      ctx.request.validate('http://example/schema/article.json');
+    });
+
+    const response = await app.subRequest(
+      'POST',
+      '/',
+      {'Content-Type': 'application/json'},
+      '{"title-typo": "foo"}'
+    );
+
+    expect(response.status).to.equal(422);
+
+  });
+
 });
+
+function getApp() {
+  const app = new Application();
+  app.use(bodyParser());
+  app.use(validator({
+    schemaPath: __dirname + '/schemas',
+    quiet: true,
+  }));
+  return app;
+
+}


### PR DESCRIPTION
This lets other middlewares directly call Ajv with all the compiled schemas.